### PR TITLE
Change for bug in template.shape

### DIFF
--- a/Tuts/template_matching.py
+++ b/Tuts/template_matching.py
@@ -12,7 +12,7 @@ img_rgb = cv2.imread('opencv-template-matching-python-tutorial.jpg')
 img_gray = cv2.cvtColor(img_rgb, cv2.COLOR_BGR2GRAY)
 
 template = cv2.imread('opencv-template-for-matching.jpg',0)
-w, h = template.shape[::-1]
+w, h = template.shape
 
 res = cv2.matchTemplate(img_gray,template,cv2.TM_CCOEFF_NORMED)
 threshold = 0.8


### PR DESCRIPTION
template is already a grayscale image, so unpacking it only needs  the output w and h. There is no need for the array handing being done.